### PR TITLE
Update Korean messages

### DIFF
--- a/lib/src/messages/languages/ko_msg.dart
+++ b/lib/src/messages/languages/ko_msg.dart
@@ -12,13 +12,13 @@ class KoreanMessages implements Messages {
   String secsAgo(int seconds) => '$seconds초';
 
   @override
-  String minAgo(int minutes) => '일분';
+  String minAgo(int minutes) => '1분';
 
   @override
   String minsAgo(int minutes) => '$minutes분';
 
   @override
-  String hourAgo(int minutes) => '한시간';
+  String hourAgo(int minutes) => '1시간';
 
   @override
   String hoursAgo(int hours) => '$hours시간';
@@ -30,5 +30,5 @@ class KoreanMessages implements Messages {
   String daysAgo(int days) => '$days일';
 
   @override
-  String wordSeparator() => '';
+  String wordSeparator() => ' ';
 }


### PR DESCRIPTION
This PR updates Korean messages, since I think these messages are more commonly used in Korean text and more appropriate to Korean spelling rule.

---

Below are my detailed reasoning for this change in Korean.

1. "일분" vs "1분", "한시간" vs "1시간"
일관성과 가독성을 위하여 숫자를 사용하는 것이 좋은 것 같습니다. 지금은 1시간을 넘는 경우에는 "2시간", "3시간"으로 표시되는데, 1시간만 "한시간"으로 표시되는 것은 약간 이상한 듯 합니다. 일관성을 위해 "1분"과 "1시간"으로 변경하고자 합니다.

2. "2시간전" vs "2시간 전"
'시간'과 '전'은 각각 명사이므로 띄어서 표기하는 것이 맞다고 합니다. [관련 링크](http://eomun.ewha.ac.kr/sub/sub05_01.php?mNum=5&sNum=1&boardid=qna&mode=view&idx=1528&goPage=&g_idx=#:~:text='%EC%97%AC'%EB%8A%94%20%EC%88%98%EB%9F%89%EC%9D%84%20%EB%82%98%ED%83%80%EB%82%B4%EB%8A%94,'%EC%A0%84'%EC%9D%80%20%EB%9D%84%EC%96%B4%20%EC%94%81%EB%8B%88%EB%8B%A4.)


감사합니다!
Thank you for maintaining this useful package!